### PR TITLE
Print usage when fails to parse subcommand.

### DIFF
--- a/src/Forge/Commands.fs
+++ b/src/Forge/Commands.fs
@@ -476,11 +476,15 @@ let parseCommand<'T when 'T :> IArgParserTemplate> args =
 let execCommand fn args =
     args |> parseCommand |> Option.bind fn
 
-
 let subCommandArgs args =
     args |> parseCommand<_>
-    |> Option.map (fun res ->
-        res.GetAllResults().Head, args.[1..]
+    |> Option.bind (fun res ->
+        match res.GetAllResults() |> List.tryHead |> Option.map (fun x -> x, args.[1..]) with
+        | None -> 
+            traceWarning "Bad or missing parameters."
+            res.Usage "   Available parameters:" |> System.Console.WriteLine
+            None
+        | x -> x
     )
 
 


### PR DESCRIPTION
Print usage of subcommand when subcommand fails to parse.

For example for
`forge.exe new projext`
the output is
```
Bad or missing parameters.
   Available parameters:

        project: Creates new project
        file: Creates new file
        solution: Creates new solution

        --help [-h|/h|/help|/?]: display this list of options.
```
instead of
```
Unhandled error:
The input list was empty.
```