### PR TITLE
Suave template targets v4.6.1 for Suave 2.0

### DIFF
--- a/suave/ApplicationName.fsproj
+++ b/suave/ApplicationName.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <Name><%= namespace %></Name>


### PR DESCRIPTION
Because [Suave v2.0 targets framework v4.6.1](https://github.com/SuaveIO/suave/blob/v2.0.0/src/Suave/Suave.fsproj#L11)



