### PR TITLE
Change build.sh permissions after rewriting it with proper line endings.

### DIFF
--- a/src/Forge.Core/Templates.fs
+++ b/src/Forge.Core/Templates.fs
@@ -191,13 +191,13 @@ module Project =
             if fake then
                 Paket.Run ["add"; "nuget"; "FAKE"]
                 Fake.Copy directory
+                let buildSh = projectDir' </> "build.sh"
+                let ctn = File.ReadAllText buildSh
+                let ctn = ctn.Replace("\r\n", "\n")
+                File.WriteAllText(buildSh, ctn)
                 if isMono then
-                    let buildSh = projectDir' </> "build.sh"
                     let perms = FilePermissions.S_IRWXU ||| FilePermissions.S_IRGRP ||| FilePermissions.S_IROTH // 0x744
                     Syscall.chmod(buildSh, perms) |> ignore
-                    let ctn = File.ReadAllText buildSh
-                    let ctn = ctn.Replace("\r\n", "\n")
-                    File.WriteAllText(buildSh, ctn)
             printfn "Done!"
         else
             printfn "Wrong template name"


### PR DESCRIPTION
Also, always write build.sh with `\n` line endings.
Fixes #35.