### PR TITLE
Fix where path has spaces

### DIFF
--- a/runners/forge.cmd
+++ b/runners/forge.cmd
@@ -1,1 +1,1 @@
-%~dp0\bin\forge.exe %*
+"%~dp0\bin\forge.exe" %*


### PR DESCRIPTION
Currently fails if `%~dp0` contains spaces. Added quotes around the path to fix.