### PR TITLE
Add support for building on NixOS.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,40 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+let
+  inherit (nixpkgs) pkgs;
+in
+  {
+  forge = pkgs.stdenv.mkDerivation {
+    name = "Forge";
+    src = pkgs.fetchFromGitHub {
+      owner = "juselius";
+      repo = "Forge";
+      rev = "ab2155e";
+      sha256 = "1sy7vq5v135xizz2mmsfdsm8aiij2rwkl0ab0k6zzi3m5aw8kfmq";
+    };
+    buildInputs = [
+      pkgs.mono
+      pkgs.fsharp
+    ];
+    configurePhase = ":";
+    buildPhase = ''
+      sed -i '
+    /^run \$PAKET_EXE restore/i \
+    export NuGetCachePath=`mktemp -d` \
+    export NUGET_PACKAGES=$NuGetCachePath/packages
+    /^run \$FAKE_EXE/a \
+    rm -rf $NuGetCachePath
+    ' build.sh
+      sed -i '
+        /==> ".*Tests"/d;
+        /^"BuildTests"$/,/==> "Release"/d
+      ' build.fsx
+      ./build.sh
+    '';
+    installPhase = ''
+      mkdir -p $out/bin
+      mkdir -p $out/libexec
+      cp -r temp $out/libexec/Forge
+      ln -s $out/libexec/Forge/forge.sh $out/bin/forge
+    '';
+  };
+}

--- a/src/Forge.Core/Forge.Core.fsproj
+++ b/src/Forge.Core/Forge.Core.fsproj
@@ -9,6 +9,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>d28ce980-2040-4b62-aca6-f07eb6b31920</ProjectGuid>
     <OutputType>Library</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5/</MonoLibraryPath>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
   </PropertyGroup>
@@ -80,6 +81,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Forge.ProjectSystem/Forge.ProjectSystem.fsproj
+++ b/src/Forge.ProjectSystem/Forge.ProjectSystem.fsproj
@@ -9,6 +9,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>9029be0f-a72c-4281-9fd1-aa15f5722306</ProjectGuid>
     <OutputType>Library</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5/</MonoLibraryPath>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
@@ -57,6 +58,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Forge/Forge.fsproj
+++ b/src/Forge/Forge.fsproj
@@ -9,6 +9,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>147b0e3c-c669-4666-8fbc-7f77cac2ff36</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5/</MonoLibraryPath>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
@@ -71,6 +72,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/tests/Forge.IntegrationTests/Forge.IntegrationTests.fsproj
+++ b/tests/Forge.IntegrationTests/Forge.IntegrationTests.fsproj
@@ -9,6 +9,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>43323d7c-a0b8-4451-add1-dad8a062cb86</ProjectGuid>
     <OutputType>Library</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5/</MonoLibraryPath>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -68,6 +69,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/tests/Forge.Tests/Forge.Tests.fsproj
+++ b/tests/Forge.Tests/Forge.Tests.fsproj
@@ -9,6 +9,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>fbaf8c7b-4eda-493a-a7fe-4db25d15736f</ProjectGuid>
     <OutputType>Library</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5/</MonoLibraryPath>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
   </PropertyGroup>
@@ -68,6 +69,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
Under Nix/NixOS the location of the Microsoft.FSharp.Targets file is a bit different than on other systems. This commit adds support for building Forge under NixOS in an unobtrusive way.