### PR TITLE
Add support for building under NixOS.

### DIFF
--- a/classlib/ApplicationName.fsproj
+++ b/classlib/ApplicationName.fsproj
@@ -7,6 +7,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid><%= guid %></ProjectGuid>
     <OutputType>Library</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
@@ -58,6 +59,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/console/ApplicationName.fsproj
+++ b/console/ApplicationName.fsproj
@@ -7,6 +7,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid><%= guid %></ProjectGuid>
     <OutputType>Exe</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
@@ -60,6 +61,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/expecto/ApplicationName.fsproj
+++ b/expecto/ApplicationName.fsproj
@@ -7,6 +7,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid><%= guid %></ProjectGuid>
     <OutputType>Exe</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
@@ -61,6 +62,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/fslabjournal/ApplicationName.fsproj
+++ b/fslabjournal/ApplicationName.fsproj
@@ -7,6 +7,7 @@
     <ProjectGuid><%= guid %></ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputType>Exe</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <RootNamespace><%= namespace %></RootNamespace>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -62,6 +63,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/fsunit/ApplicationName.fsproj
+++ b/fsunit/ApplicationName.fsproj
@@ -7,6 +7,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid><%= guid %></ProjectGuid>
     <OutputType>Library</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
@@ -59,6 +60,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/nancyselfhosted/ApplicationName.fsproj
+++ b/nancyselfhosted/ApplicationName.fsproj
@@ -9,6 +9,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>f79cf42f-5b7d-4491-8438-42b3ca4e59d4</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
@@ -53,6 +54,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/pcl259/ApplicationName.fsproj
+++ b/pcl259/ApplicationName.fsproj
@@ -7,6 +7,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid><%= guid %></ProjectGuid>
     <OutputType>Library</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>

--- a/servicefabricsuavestateless/ApplicationName.fsproj
+++ b/servicefabricsuavestateless/ApplicationName.fsproj
@@ -6,6 +6,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid><%= guid %></ProjectGuid>
     <OutputType>Exe</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
@@ -51,6 +52,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/suave/ApplicationName.fsproj
+++ b/suave/ApplicationName.fsproj
@@ -7,6 +7,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid><%= guid %></ProjectGuid>
     <OutputType>Exe</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
@@ -63,6 +64,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/websharperserverclient/ApplicationName.fsproj
+++ b/websharperserverclient/ApplicationName.fsproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <Name><%= namespace %></Name>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
@@ -146,6 +147,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/websharperspa/ApplicationName.fsproj
+++ b/websharperspa/ApplicationName.fsproj
@@ -16,6 +16,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
         <OutputType>Library</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <Name><%= namespace %></Name>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
@@ -121,6 +122,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/websharpersuave/ApplicationName.fsproj
+++ b/websharpersuave/ApplicationName.fsproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <Name><%= namespace %></Name>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
@@ -65,6 +66,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/windows/ApplicationName.fsproj
+++ b/windows/ApplicationName.fsproj
@@ -6,6 +6,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid><%= guid %></ProjectGuid>
     <OutputType>WinExe</OutputType>
+    <MonoLibraryPath>/run/current-system/sw/lib/mono/4.5</MonoLibraryPath>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -71,6 +72,9 @@
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+      <PropertyGroup Condition="Exists('$(MonoLibraryPath)/Microsoft.FSharp.Targets')">
+          <FSharpTargetsPath>$(MonoLibraryPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
Under Nix/NixOS the location of the Microsoft.FSharp.Targets file is a bit different than on other systems. This commit adds NixOS support to the Forge templates in an unobtrusive way.