### PR TITLE
Check validity of new project name and project directory.

### DIFF
--- a/src/Forge.Core/Templates.fs
+++ b/src/Forge.Core/Templates.fs
@@ -152,10 +152,14 @@ module Project =
 
         let templates = GetList()
 
+        let pathCheck path = 
+            try Path.GetFullPath path |> ignore; isValidPath path
+            with _ -> false
+
         let projectName' =
             match projectName with
             | Some p -> p
-            | None -> prompt "Enter project name:"
+            | None -> promptCheck "Enter project name:" (fun p -> pathCheck (directory </> p)) (sprintf "%s is not valid project name.")
         let projectDir' =
             match projectDir with
             | Some p -> p

--- a/src/Forge.Core/Templates.fs
+++ b/src/Forge.Core/Templates.fs
@@ -154,7 +154,7 @@ module Project =
 
         let pathCheck path = 
             let path' = directory </> path
-            try Path.GetFullPath path' |> ignore; isValidPath path' && String.stripControls path <> ""
+            try Path.GetFullPath path' |> ignore; isValidPath path' && not (String.IsNullOrWhiteSpace path)
             with _ -> false
 
         let projectName' =

--- a/src/Forge.Core/Templates.fs
+++ b/src/Forge.Core/Templates.fs
@@ -153,17 +153,26 @@ module Project =
         let templates = GetList()
 
         let pathCheck path = 
-            try Path.GetFullPath path |> ignore; isValidPath path
+            let path' = directory </> path
+            try Path.GetFullPath path' |> ignore; isValidPath path' && String.stripControls path <> ""
             with _ -> false
 
         let projectName' =
             match projectName with
             | Some p -> p
-            | None -> promptCheck "Enter project name:" (fun p -> pathCheck (directory </> p)) (sprintf "%s is not valid project name.")
+            | None -> 
+                promptCheck 
+                    "Enter project name:" 
+                    pathCheck 
+                    (sprintf "\"%s\" is not a valid project name.")
         let projectDir' =
             match projectDir with
             | Some p -> p
-            | None -> prompt "Enter project directory (relative to working directory):"
+            | None -> 
+                promptCheck 
+                    "Enter project directory (relative to working directory):" 
+                    pathCheck
+                    (sprintf "\"%s\" is not a valid directory name.")
         let templateName' =
             match templateName with
             | Some p -> p
@@ -172,7 +181,11 @@ module Project =
         let templateDir = templatesLocation </> templateName'
         let gitignorePath = (templatesLocation </> ".vcsignore" </> ".gitignore")
 
-        if templates |> Seq.contains templateName' then
+        if pathCheck projectFolder |> not then
+            printfn "\"%s\" is not a valid project folder." projectFolder
+        elif templates |> Seq.contains templateName' |> not then
+            printfn "Wrong template name"
+        else
             printfn "Generating project..."
             copyDir projectFolder templateDir (fun _ -> true)
             applicationNameToProjectName projectFolder projectName'
@@ -203,8 +216,6 @@ module Project =
                     let perms = FilePermissions.S_IRWXU ||| FilePermissions.S_IRGRP ||| FilePermissions.S_IROTH // 0x744
                     Syscall.chmod(buildSh, perms) |> ignore
             printfn "Done!"
-        else
-            printfn "Wrong template name"
 
 module File =
     open System

--- a/src/Forge.ProjectSystem/Prelude.fs
+++ b/src/Forge.ProjectSystem/Prelude.fs
@@ -128,6 +128,15 @@ let promptSelect2 text list =
      Console.Write("> ")
      Console.ReadLine () |> String.stripControls
 
+let promptCheck text checkF wrongInputMessage =
+    let rec ask() =
+        let x = prompt text
+        if checkF x then x
+        else
+            printfn "%s" (wrongInputMessage x)
+            ask()
+
+    ask()
 
 let inline mapOpt (opt:'a option) mapfn (x:'b) =
     match opt with


### PR DESCRIPTION
In "new project" command check if project name is not whitespace and it is valid directory name; if not, we ask again. Same for project directory.

Fixes #45.