### PR TITLE
Paket.Init function replace Copy and fixes #58

### DIFF
--- a/src/Forge.Core/Paket.fs
+++ b/src/Forge.Core/Paket.fs
@@ -9,16 +9,21 @@ let getPaketLocation () =
     if Directory.Exists local then local else paketLocation
 
 let getPaket () =
-    let local = directory </> ".paket" </> "paket.exe"
-    if File.Exists local then local else paketLocation </> "paket.exe"
+    getPaketLocation () </> "paket.exe"
 
-
-let Copy folder =
+let copy folder =
     folder </> ".paket" |> Directory.CreateDirectory |> ignore
     Directory.GetFiles location
     |> Seq.iter (fun x ->
-        let fn = Path.GetFileName x
-        File.Copy (x, folder </> ".paket" </> fn, true) )
+        let filename = Path.GetFileName x
+        File.Copy (x, folder </> ".paket" </> filename, true) )
+
+
+let Init folder =
+    if Directory.GetFiles folder |> Seq.exists (fun n -> n.EndsWith "paket.dependencies") |> not then
+        copy folder
+        Update ()
+        Run ["init"]
 
 let Update () =
     let f = getPaketLocation ()

--- a/src/Forge.Core/Paket.fs
+++ b/src/Forge.Core/Paket.fs
@@ -19,12 +19,6 @@ let copy folder =
         File.Copy (x, folder </> ".paket" </> filename, true) )
 
 
-let Init folder =
-    if Directory.GetFiles folder |> Seq.exists (fun n -> n.EndsWith "paket.dependencies") |> not then
-        copy folder
-        Update ()
-        Run ["init"]
-
 let Update () =
     let f = getPaketLocation ()
     run (f </> "paket.bootstrapper.exe") "" f
@@ -35,5 +29,9 @@ let Run args =
     let args' = args |> String.concat " "
     run f args' directory
 
-
+let Init folder =
+    if Directory.GetFiles folder |> Seq.exists (fun n -> n.EndsWith "paket.dependencies") |> not then
+        copy folder
+        Update ()
+        Run ["init"]
 

--- a/src/Forge.Core/Templates.fs
+++ b/src/Forge.Core/Templates.fs
@@ -180,9 +180,7 @@ module Project =
             sed "<%= paketPath %>" (relative directory) projectFolder
             sed "<%= packagesPath %>" (relative packagesDirectory) projectFolder
 
-            Paket.Copy directory
-            if Directory.GetFiles directory |> Seq.exists (fun n -> n.EndsWith "paket.dependencies") |> not then
-                Paket.Run ["init"]
+            Paket.Init directory
 
             Directory.GetFiles projectFolder
             |> Seq.tryFind (fun n -> n.EndsWith "paket.references")


### PR DESCRIPTION
This undoes part of #49 but works reliably.  The existing `paket.exe` file should be able to be removed, but I didn't do it in this commit as it might break some compatibility.

The PR to master should happen after PR to templates... (or near same time)