### PR TITLE
Make forge template directory configurable via environment

### DIFF
--- a/src/Forge.Core/Environment.fs
+++ b/src/Forge.Core/Environment.fs
@@ -86,7 +86,12 @@ let exeLocation =
         System.Reflection.Assembly.GetEntryAssembly().Location |> Path.GetDirectoryName
     with
     | _ -> ""
-let templatesLocation = exeLocation </> ".." </> "templates"
+
+let templatesLocation =
+    match Environment.GetEnvironmentVariable "FORGE_TEMPLATE_DIR" with
+    | null -> exeLocation </> ".." </> "templates"
+    | dir -> dir
+
 let directory         = System.Environment.CurrentDirectory
 let packagesDirectory = directory </> "packages"
 
@@ -107,4 +112,3 @@ let relative (path1 : string) (path2 : string) =
             .ToString()
             .Replace('/', Path.DirectorySeparatorChar)
     )
-


### PR DESCRIPTION
I would like to add a check for an env var to be able to set the template directory location. In a nix based system, the templates directory has to reside in a read-only location, so when a new project is created the permissions for the copied files are read-only, causing the bootstrapping to fail. Being able to set the location of the templates to be outside of the forge directory would solve this issue. 