### PR TITLE
Resolve BadImageFormatException on Mono (fix #90)

### DIFF
--- a/src/Forge/app.config
+++ b/src/Forge/app.config
@@ -4,7 +4,7 @@
   <runtime>
     
   <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-  <probing privatePath="bin" />
+  <probing privatePath="Bin" />
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
Case-sensitivity matters. :)