### PR TITLE
List projects by folder

### DIFF
--- a/src/Forge.Core/ProjectManager.fs
+++ b/src/Forge.Core/ProjectManager.fs
@@ -290,6 +290,21 @@ module Furnace =
         |> List.iter trace
         state
 
+    let listProjects (folder: string option) (filter: string option) =
+        let filterFn =
+            match filter with
+            | Some s -> (fun fileName -> (String.editDistance fileName s) < 5)
+            | None   -> (fun _ -> true)
+        let dir =
+            match folder with
+            | Some s -> s 
+            | None   -> getCwd() + Path.DirectorySeparatorChar.ToString()
+        Globbing.search dir "**/*proj"
+        |> List.filter (fun s -> System.IO.Path.GetFileNameWithoutExtension(s) |> filterFn)
+        |> List.map (fun s -> relative s dir)
+        |> List.iter trace
+
+
     let rec tryFindProject dir =
         try
             let dir =

--- a/src/Forge/Commands.fs
+++ b/src/Forge/Commands.fs
@@ -398,7 +398,7 @@ type ListProjectsArgs =
         member this.Usage =
             match this with
             | Solution _ -> "List the projects in this solution"
-            | Folder _ -> "List the projects in this directory"
+            | Folder _ -> "List the projects in this and any subfolders"
             | Filter _ -> "Filter list via fuzzy search for this string"
 
 type ListGacArgs =
@@ -783,12 +783,15 @@ let listProjectReferences (results : ParseResults<ListProjectReferencesArgs>) =
         |> ignore
     }
 
-
-let listProject (results : ParseResults<ListProjectsArgs>) =
+let listProjects (results : ParseResults<ListProjectsArgs>) =
     maybe {
-        let! solution = results.TryGetResult <@ ListProjectsArgs.Solution @>
+        let solution = results.TryGetResult <@ ListProjectsArgs.Solution @>  // TODO: solution and folder should be mutually exclusive
         let filter = results.TryGetResult <@ ListProjectsArgs.Filter @>
-        traceWarning "not implemented yet" //TODO
+        let folder = results.TryGetResult <@ ListProjectsArgs.Folder @>
+        if solution <> None then
+            traceWarning "Listing projects from solution not yet implemented."
+        else
+            Furnace.listProjects folder filter
     }
 
 let listGac (results : ParseResults<ListGacArgs>) =
@@ -806,7 +809,7 @@ let processList args =
     match subCommandArgs args with
     | Some (cmd, subArgs) ->
         match cmd with
-        | ListCommands.Project   -> execCommand listProject subArgs
+        | ListCommands.Project   -> execCommand listProjects subArgs
         | ListCommands.File      -> execCommand listFiles subArgs
         | ListCommands.Reference -> execCommand listReferences subArgs
         | ListCommands.GAC       -> execCommand listGac subArgs

--- a/tests/Forge.IntegrationTests/Helpers.fs
+++ b/tests/Forge.IntegrationTests/Helpers.fs
@@ -18,6 +18,18 @@ let initTest dir args =
         let a = a + " --no-prompt"
         Forge.App.main (a.Split ' ') |> ignore)
 
+let runForgeWithOutput args =
+    let sw = new System.IO.StringWriter()
+    System.Console.SetOut(sw)
+    args |> List.iter (fun a ->
+        let a = a + " --no-prompt"
+        Forge.App.main (a.Split ' ') |> ignore)
+    let so = new System.IO.StreamWriter(System.Console.OpenStandardOutput())
+    so.AutoFlush <- true
+    System.Console.SetOut(so)
+    sw.ToString()
+
+
 let getPath file =
     cwd </> file
 

--- a/tests/Forge.IntegrationTests/Tests.fs
+++ b/tests/Forge.IntegrationTests/Tests.fs
@@ -1,6 +1,8 @@
 module Tests
 
 open Expecto
+open Forge.Environment
+open Forge
 
 [<Tests>]
 let tests =
@@ -268,5 +270,28 @@ let tests =
         |> initTest dir
         let project = dir </> "src" </> "Sample" </> "Sample.fsproj" |> loadProject
         project |> Expect.hasFile "Renamed.fs"
+    ]
+    testList "List output" [
+        testCase "List files in fsproj" <| fun _ ->
+            let s = "Sample.fs" + System.Environment.NewLine + "App.config" + System.Environment.NewLine
+            let dir = "list_files"
+            ["new project -n Sample --dir src -t console --no-paket"]
+            |> initTest dir
+            ["list files -p src/Sample/Sample.fsproj"]
+            |> runForgeWithOutput
+            |> Expecto.Flip.Expect.equal "should be equal" s
+
+        testCase "List projects in folder" <| fun _ ->
+            let s1 = "src" </> "Sample" </> "Sample.fsproj"
+            let s2 = "src" </> "Sample2" </> "Sample2.fsproj"
+            let s = s1 + System.Environment.NewLine + s2 + System.Environment.NewLine
+            let dir = "list_projects"
+            ["new project -n Sample --dir src -t console --no-paket"
+             "new project -n Sample2 --dir src -t console --no-paket"
+            ]
+            |> initTest dir
+            ["list projects --folder src"]
+            |> runForgeWithOutput 
+            |> Expecto.Flip.Expect.equal "should be equal" s
     ]
   ]


### PR DESCRIPTION
Implemented the command to list projects by folder. It will list all projects in a given folder or any subfolders. 

This looks in any subfolders from the supplied folder as just listing the project(s) in a specific given folder didn't seem overly useful.
