### PR TITLE
add Fake into build group

### DIFF
--- a/src/Forge.Core/Templates.fs
+++ b/src/Forge.Core/Templates.fs
@@ -215,7 +215,7 @@ module Project =
                 |> Option.iter (File.ReadAllLines >> Seq.iter (fun ref -> Paket.Run ["add"; ref; "--no-resolve"]) )
 
             if fake then
-                if paket then Paket.Run ["add"; "FAKE"; "--no-resolve"]
+                if paket then Paket.Run ["add"; "FAKE"; "--no-resolve"; "--group Build"]
                 Fake.Copy ^ getCwd()
                 let buildSh = getCwd() </> "build.sh"
                 let ctn = File.ReadAllText buildSh


### PR DESCRIPTION
Adding FAKE into a dedicated build group. That way resolving FAKE will not influence resolving the main group used for runtime dependencies. 